### PR TITLE
Update SendRequestAction.java

### DIFF
--- a/core/src/main/java/org/peter/unomi/customwebhook/actions/SendRequestAction.java
+++ b/core/src/main/java/org/peter/unomi/customwebhook/actions/SendRequestAction.java
@@ -36,7 +36,8 @@ public class SendRequestAction implements ActionExecutor {
 
         logger.info("Start webhook action.");
         if (httpClient == null) {
-            int timeout = 1;
+            // TODO can be configurable depends on behavior of the request.
+            int timeout = 10;
             RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(timeout * 1000)
                     .setConnectionRequestTimeout(timeout * 1000).setSocketTimeout(timeout * 1000).build();
             httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build();


### PR DESCRIPTION
Request timeout of 1 second doesn't work for real case scenario. My proposal is to increase it at least 10 times since this is not configurable yet.